### PR TITLE
Rajout de Pokemin dans Configgen.

### DIFF
--- a/configgen/emulatorlauncher.py
+++ b/configgen/emulatorlauncher.py
@@ -8,6 +8,7 @@ import generators
 from generators.libretro.libretroGenerator import LibretroGenerator
 from generators.fba2x.fba2xGenerator import Fba2xGenerator
 from generators.mupen.mupenGenerator import MupenGenerator
+from generators.pokemini.pokeminiGenerator import pokeminiGenerator
 from generators.kodi.kodiGenerator import KodiGenerator
 from generators.moonlight.moonlightGenerator import MoonlightGenerator
 from generators.scummvm.scummvmGenerator import ScummVMGenerator
@@ -22,6 +23,7 @@ generators = {
     'libretro': LibretroGenerator(),
     'fba2x': Fba2xGenerator(),
     'mupen64plus': MupenGenerator(),
+    'pokemini': pokeminiGenerator(),
     'kodi': KodiGenerator(),
     'moonlight': MoonlightGenerator(),
     'scummvm': ScummVMGenerator()
@@ -38,6 +40,7 @@ emulators["gb"] = Emulator(name='gb', emulator='libretro', core='gambatte')
 emulators["gbc"] = Emulator(name='gbc', emulator='libretro', core='gambatte')
 emulators["fds"] = Emulator(name='fds', emulator='libretro', core='nestopia')
 emulators["virtualboy"] = Emulator(name='virtualboy', emulator='libretro', core='vb')
+emulators["pokemon"] = Emulator(name='pokemon', emulator='pokemini')
 # Sega
 emulators["sg1000"] = Emulator(name='sg1000', emulator='libretro', core='genesisplusgx')
 emulators["mastersystem"] = Emulator(name='mastersystem', emulator='libretro', core='picodrive')

--- a/configgen/generators/pokemini/pokeminiGenerator.py
+++ b/configgen/generators/pokemini/pokeminiGenerator.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import Command
+import recalboxFiles
+import shutil
+from generators.Generator import Generator
+import os.path
+
+class PokeminiGenerator(Generator):
+    # Main entry of the module
+    # Configure pokemini and return a command
+    def generate(self, system, rom, playersControllers):
+        # Settings recalbox default config file if no user defined one
+        
+
+        commandArray = [recalboxFiles.pokeminiBin]

--- a/configgen/recalboxFiles.py
+++ b/configgen/recalboxFiles.py
@@ -25,6 +25,10 @@ fbaCustom = fbaRoot + 'fba2x.cfg'
 fbaCustomOrigin = fbaRoot + 'fba2x.cfg.origin'
 fba2xBin = '/usr/bin/fba2x'
 
+pokeminiBin = '/usr/emulators/pokemini/PokeMini'
+pokeminiCustom = '/usr/emulators/pokemini/pokemini.cfg'
+pokeminiJoy = '/usr/emulators/pokemini/pokemini_sdl2.cfg'
+
 mupenConf = CONF + '/mupen64/'
 mupenCustom = mupenConf + "mupen64plus.cfg"
 mupenInput = mupenConf + "InputAutoCfg.ini"


### PR DESCRIPTION
Rajout de Pokemini sans les options de configuration de manettes car ne pouvant pas faire de tests, je ne l'ai pas rajouter comme les options scanline que je trouve inutilisable avec cette console même si disponible.