### PR TITLE
Bug fix in TestLinappleConfig.test02_save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ target/
 
 .idea
 .idea/*
+
+configgen/tests/tmp/

--- a/configgen/tests/generators/linapple/test_linappleConfig.py
+++ b/configgen/tests/generators/linapple/test_linappleConfig.py
@@ -35,6 +35,7 @@ class TestLinappleConfig(runtest.TestCase):
         runtest.TestCase.tearDownClass()
     
     def setUp(self):
+        super(self.__class__, self).setUp()
         self.maxDiff = None
         
     def tearDown(self):


### PR DESCRIPTION
- As the tmp/linapple directory is created by the base class, it's better to call it before creating the file. :-)
- Also add tests/tmp directory to .gitignore