### PR TITLE
n64: change default deadzone from 4096 to 0

### DIFF
--- a/configgen/recalboxFiles.py
+++ b/configgen/recalboxFiles.py
@@ -31,6 +31,8 @@ mupenConf = CONF + '/mupen64/'
 mupenCustom = mupenConf + "mupen64plus.cfg"
 mupenInput = mupenConf + "InputAutoCfg.ini"
 mupenSaves = SAVES + "/n64"
+mupenMappingUser    = mupenConf + 'input.xml'
+mupenMappingSystem  = '/recalbox/share_init/system/configs/mupen64/input.xml'
 
 shaderPresetRoot = "/recalbox/share_init/system/configs/shadersets/"
 


### PR DESCRIPTION
not sure it works 100% please reread/retest.

007 just becomes playable.
the pad is really more sensitve and precise for several games.
i've no soucy with a 0 deadzone.
But for people who go soucy, i make it customisable.
Please double check this commit while the n64 configuration looks wired to me,
so, i'm not sure to not add a bug, even if i've a tested several things.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>