### PR TITLE
Add new possibilities for user customization

### DIFF
--- a/configgen/emulatorlauncher.py
+++ b/configgen/emulatorlauncher.py
@@ -61,7 +61,7 @@ emulators["dreamcast"] = Emulator(name='dreamcast', emulator='reicast')
 emulators["neogeo"] = Emulator(name='neogeo', emulator='fba2x')
 emulators["mame"] = Emulator(name='mame', emulator='libretro', core='mame078')
 emulators["fba"] = Emulator(name='fba', emulator='fba2x')
-emulators["fba_libretro"] = Emulator(name='fbalibretro', emulator='libretro', core='fba')
+emulators["fba_libretro"] = Emulator(name='fba_libretro', emulator='libretro', core='fba')
 # Computers
 emulators["msx"] = Emulator(name='msx', emulator='libretro', core='bluemsx')
 emulators["msx1"] = Emulator(name='msx1', emulator='libretro', core='bluemsx')

--- a/configgen/generators/libretro/libretroConfig.py
+++ b/configgen/generators/libretro/libretroConfig.py
@@ -35,7 +35,7 @@ coreToP2Device = {'fuse': '513', 'snes9x_next': '257' };
 systemToRetroachievements = {'snes', 'nes', 'gba', 'gb', 'gbc', 'megadrive', 'pcengine'};
 
 # Define systems not compatible with rewind option
-systemNoRewind = {'virtualboy', 'sega32x', 'segacd', 'psx', 'fbalibretro', 'vectrex', 'zxspectrum', 'odyssey2', 'mame'};
+systemNoRewind = {'virtualboy', 'sega32x', 'segacd', 'psx', 'fba_libretro', 'vectrex', 'zxspectrum', 'odyssey2', 'mame'};
 
 # Netplay modes
 systemNetplayModes = {'host', 'client'}

--- a/configgen/generators/libretro/libretroGenerator.py
+++ b/configgen/generators/libretro/libretroGenerator.py
@@ -33,17 +33,17 @@ class LibretroGenerator(Generator):
         configToAppend = []
         
         # Custom configs - per core
-        customCfg = "/recalbox/share/system/configs/retroarch/{}.cfg".format(system.name)
+        customCfg = "{}/{}.cfg".format(recalboxFiles.retroarchRoot, system.name)
         if os.path.isfile(customCfg):
             configToAppend.append(customCfg)
         
         # Custom configs - per game
-        customGameCfg = "/recalbox/share/system/configs/retroarch/{}/{}.cfg".format(system.name, romName)
+        customGameCfg = "{}/{}/{}.cfg".format(recalboxFiles.retroarchRoot, system.name, romName)
         if os.path.isfile(customGameCfg):
             configToAppend.append(customGameCfg)
         
         # Overlay management
-        overlayFile = "/recalbox/share/roms/{}/{}.cfg".format(system.name, romName)
+        overlayFile = "{}/{}/{}.cfg".format(recalboxFiles.OVERLAYS, system.name, romName)
         if os.path.isfile(overlayFile):
             configToAppend.append(overlayFile)
         

--- a/configgen/generators/libretro/libretroGenerator.py
+++ b/configgen/generators/libretro/libretroGenerator.py
@@ -26,15 +26,32 @@ class LibretroGenerator(Generator):
 
         # Retroarch core on the filesystem
         retroarchCore = recalboxFiles.retroarchCores + system.config['core'] + recalboxFiles.libretroExt
+        romName = os.path.basename(rom)
 
         # the command to run
+        commandArray = [recalboxFiles.retroarchBin, "-L", retroarchCore, "--config", system.config['configfile']]
+        
+        # Custom configs - per core
+        customCfg = "/recalbox/share/system/configs/retroarch/{}.cfg".format(system.name)
+        if os.path.isfile(customCfg):
+            commandArray.extend(["--append", customCfg])
+        
+        # Custom configs - per game
+        customGameCfg = "/recalbox/share/system/configs/retroarch/{}/{}.cfg".format(system.name, romName)
+        if os.path.isfile(customCfg):
+            commandArray.extend(["--append", customGameCfg])
+        
+        # Overlay management
+        overlayFile = "/recalbox/share/roms/{}/{}.cfg".format(system.name, romName)
+        if os.path.isfile(overlayFile):
+            commandArray.extend(["--append", overlayFile])
+            
+         # Netplay mode
         if 'netplaymode' in system.config:
             if system.config['netplaymode'] == 'host':
-                commandArray = [recalboxFiles.retroarchBin, "-L", retroarchCore, "--config", system.config['configfile'], "--host", "-v", rom]
+                commandArray.append("--host")
             elif system.config['netplaymode'] == 'client':
-                commandArray = [recalboxFiles.retroarchBin, "-L", retroarchCore, "--config", system.config['configfile'], "--connect", system.config['netplay.server.address'], "-v", rom]
-        else:
-            commandline = '{} -L "{}" --config "{}" "{}"'.format(recalboxFiles.retroarchBin, retroarchCore, system.config['configfile'], rom)
-            commandArray = [recalboxFiles.retroarchBin, "-L", retroarchCore, "--config", system.config['configfile'], rom]
-
+                commandArray.extend(["--connect", system.config['netplay.server.address']])
+        
+        commandArray.append(rom)
         return Command.Command(videomode=system.config['videomode'], array=commandArray)

--- a/configgen/generators/libretro/libretroGenerator.py
+++ b/configgen/generators/libretro/libretroGenerator.py
@@ -30,21 +30,26 @@ class LibretroGenerator(Generator):
 
         # the command to run
         commandArray = [recalboxFiles.retroarchBin, "-L", retroarchCore, "--config", system.config['configfile']]
+        configToAppend = []
         
         # Custom configs - per core
         customCfg = "/recalbox/share/system/configs/retroarch/{}.cfg".format(system.name)
         if os.path.isfile(customCfg):
-            commandArray.extend(["--append", customCfg])
+            configToAppend.append(customCfg)
         
         # Custom configs - per game
         customGameCfg = "/recalbox/share/system/configs/retroarch/{}/{}.cfg".format(system.name, romName)
-        if os.path.isfile(customCfg):
-            commandArray.extend(["--append", customGameCfg])
+        if os.path.isfile(customGameCfg):
+            configToAppend.append(customGameCfg)
         
         # Overlay management
         overlayFile = "/recalbox/share/roms/{}/{}.cfg".format(system.name, romName)
         if os.path.isfile(overlayFile):
-            commandArray.extend(["--append", overlayFile])
+            configToAppend.append(overlayFile)
+        
+        # Generate the append
+        if configToAppend:
+            commandArray.extend(["--appendconfig", "|".join(configToAppend)])
             
          # Netplay mode
         if 'netplaymode' in system.config:

--- a/configgen/recalboxFiles.py
+++ b/configgen/recalboxFiles.py
@@ -5,6 +5,7 @@ CONF = HOME + '/configs'
 SAVES = '/recalbox/share/saves'
 SCREENSHOTS = '/recalbox/share/screenshots'
 BIOS = '/recalbox/share/bios'
+OVERLAYS = '/recalbox/share/overlays'
 
 esInputs = HOME + '/.emulationstation/es_input.cfg'
 esSettings = HOME + '/.emulationstation/es_settings.cfg'

--- a/configgen/utils/videoMode.py
+++ b/configgen/utils/videoMode.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 import os
+import sys
+import recalboxFiles
+from settings.unixSettings import UnixSettings
 
 # Set a specific video mode
 def setVideoMode(videomode):
@@ -15,4 +18,9 @@ def isSupported(index, mode="CEA", drive="HDMI"):
 
 # Switch to prefered mode
 def setPreffered():
-    os.system("tvservice -p")
+    recalSettings = UnixSettings(recalboxFiles.recalboxConf)
+    esVideoMode = recalSettings.load('system.es.videomode')
+    if esVideoMode is None:
+        os.system("tvservice -p")
+    else:
+        os.system("tvservice -e '{}'".format(esVideoMode))


### PR DESCRIPTION
- loads an overlay configuration file if available as `/recalbox/share/overlays/<system>/<rom>.cfg` if the file exists
- can append a `/recalbox/share/system/configs/retroarch/<system>.cfg` file to retroarch config for a per system custom config if the file exists
- can append a `/recalbox/share/system/configs/retroarch/<system>/<rom>.cfg` file to retroarch config for a per game custom config if the file exists
- handle the new system.es.videomode in recalbox.conf to set the resolution once leaving the emulator

In both cases rom = rom file name + extension. For ex : commando.zip, so the expected cfg file is commando.zip.cfg