### PR TITLE
dosbox: don't read the default ~/.dosbox/dosboxSVN.conf file

### DIFF
--- a/configgen/generators/dosbox/dosboxGenerator.py
+++ b/configgen/generators/dosbox/dosboxGenerator.py
@@ -23,5 +23,7 @@ class DosBoxGenerator(Generator):
         if os.path.isfile(gameConfFile):
             commandArray.append("-conf")
             commandArray.append("""{}""".format(gameConfFile))
-			
+        else:
+            commandArray.append("-conf")
+            commandArray.append("""{}""".format("/recalbox/share/system/configs/dosbox/dosbox.conf"))
         return Command.Command(videomode='default', array=commandArray, env={"SDL_VIDEO_GL_DRIVER":"/usr/lib/libGLESv2.so"})

--- a/configgen/generators/dosbox/dosboxGenerator.py
+++ b/configgen/generators/dosbox/dosboxGenerator.py
@@ -25,5 +25,5 @@ class DosBoxGenerator(Generator):
             commandArray.append("""{}""".format(gameConfFile))
         else:
             commandArray.append("-conf")
-            commandArray.append("""{}""".format("/recalbox/share/system/configs/dosbox/dosbox.conf"))
+            commandArray.append("""{}""".format(recalboxFiles.dosboxConfig))
         return Command.Command(videomode='default', array=commandArray, env={"SDL_VIDEO_GL_DRIVER":"/usr/lib/libGLESv2.so"})

--- a/configgen/recalboxFiles.py
+++ b/configgen/recalboxFiles.py
@@ -64,4 +64,7 @@ ppssppBin = '/usr/bin/PPSSPPSDL'
 ppssppControls = CONF + '/ppsspp/PSP/SYSTEM/controls.ini'
 ppssppControlsInit = HOME_INIT + 'configs/ppsspp/PSP/SYSTEM/controls.ini'
 
+dosboxCustom = CONF + '/dosbox'
+dosboxConfig = dosboxCustom + '/dosbox.conf'
+
 logdir = HOME + '/logs/'


### PR DESCRIPTION
choose the one in configs. Note that this is the wrong one is fsoverlay of buildroot too.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>