### PR TITLE
Add a ##args## emulator option

### DIFF
--- a/configgen/Emulator.py
+++ b/configgen/Emulator.py
@@ -3,6 +3,7 @@ import os
 import recalboxFiles
 from settings.unixSettings import UnixSettings
 import xml.etree.ElementTree as ET
+import shlex
 
 class Emulator():
 
@@ -19,6 +20,7 @@ class Emulator():
         self.config['configfile'] = configfile
         self.config['netplay']    = None
         self.config['showFPS']    = showFPS
+        self.config['args']       = None
         
     def configure(self, emulator='default', core='default', ratio='auto', netplay=None):
         recalSettings = UnixSettings(recalboxFiles.recalboxConf)
@@ -45,6 +47,13 @@ class Emulator():
         # Draw FPS
         if self.config['showFPS'] is None or self.config['showFPS'] not in ['false', 'true']:
             self.updateDrawFPS()
+        # Optionnal emulator args ONLY if security is disabled
+        recalSettings = UnixSettings(recalboxFiles.recalboxConf)
+        security = recalSettings.load("system.security.enabled")
+        if (security != "1" and'args' in settings and settings['args'] != ''):
+            self.config['args'] = shlex.split(settings['args'])
+        else:
+            self.config['args'] = None
 
     def updateShaders(self, shaderSet):
         if shaderSet != None and shaderSet != 'none':
@@ -67,4 +76,3 @@ class Emulator():
         if value not in ['false', 'true']:
             value = 'false'
         self.config['showFPS'] = value
-        

--- a/configgen/generators/dolphin/dolphinGenerator.py
+++ b/configgen/generators/dolphin/dolphinGenerator.py
@@ -12,4 +12,6 @@ class DolphinGenerator(Generator):
         dolphinControllers.generateControllerConfig(system, playersControllers)
 
         commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], "-e", rom]
+        if 'args' in system.config and system.config['args'] is not None:
+             commandArray.extend(system.config['args'])
         return Command.Command(videomode=system.config['videomode'], array=commandArray, env={"XDG_CONFIG_HOME":recalboxFiles.CONF, "XDG_DATA_HOME":recalboxFiles.SAVES})

--- a/configgen/generators/dosbox/dosboxGenerator.py
+++ b/configgen/generators/dosbox/dosboxGenerator.py
@@ -26,4 +26,6 @@ class DosBoxGenerator(Generator):
         else:
             commandArray.append("-conf")
             commandArray.append("""{}""".format(recalboxFiles.dosboxConfig))
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
         return Command.Command(videomode='default', array=commandArray, env={"SDL_VIDEO_GL_DRIVER":"/usr/lib/libGLESv2.so"})

--- a/configgen/generators/fba2x/fba2xGenerator.py
+++ b/configgen/generators/fba2x/fba2xGenerator.py
@@ -23,5 +23,8 @@ class Fba2xGenerator(Generator):
             # Write configuration to retroarchcustom.cfg
             fba2xConfig.writeFBAConfig(system)
 
-        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], "--configfile", system.config['configfile'], '--logfile', recalboxFiles.logdir+"/fba2x.log", rom]
+        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], "--configfile", system.config['configfile'], '--logfile', recalboxFiles.logdir+"/fba2x.log"]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+        commandArray.append(rom)
         return Command.Command(videomode=system.config['videomode'], array=commandArray)

--- a/configgen/generators/libretro/libretroGenerator.py
+++ b/configgen/generators/libretro/libretroGenerator.py
@@ -58,5 +58,9 @@ class LibretroGenerator(Generator):
             elif system.config['netplaymode'] == 'client':
                 commandArray.extend(["--connect", system.config['netplay.server.address']])
         
+        # Optionnal arguments
+        if 'args' in system.config and system.config['args'] is not None:
+             commandArray.extend(system.config['args'])
+             
         commandArray.append(rom)
         return Command.Command(videomode=system.config['videomode'], array=commandArray)

--- a/configgen/generators/linapple/linappleGenerator.py
+++ b/configgen/generators/linapple/linappleGenerator.py
@@ -95,7 +95,11 @@ class LinappleGenerator(Generator):
 
         # Save changes 
         config.save(filename=usr_conf)
-        return Command.Command(videomode=system.config['videomode'], array=[ recalboxFiles.recalboxBins[system.config['emulator']] ])
+        commandArray = [ recalboxFiles.recalboxBins[system.config['emulator']] ]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+
+        return Command.Command(videomode=system.config['videomode'], array=commandArray)
 
     def config_upgrade(self, version):
         '''

--- a/configgen/generators/moonlight/moonlightGenerator.py
+++ b/configgen/generators/moonlight/moonlightGenerator.py
@@ -17,6 +17,8 @@ class MoonlightGenerator(Generator):
         # stream -remote -keydir ${moonlight_keydir} -${moonlight_screen} -${moonlight_fps} -mapping ${moonlight_mapping} -app \"$game\" ${moonlight_ip}"
         # commandArray = [recalboxFiles.moonlightBin, 'stream','-remote', '-keydir', recalboxFiles.moonlightCustom + '/keydir', '-720',  '-60fps']
         commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], 'stream','-config',  recalboxFiles.moonlightConfig]
+        if 'args' in system.config and system.config['args'] is not None:
+             commandArray.extend(system.config['args'])
         for mapping in config:
             commandArray.append('-mapping')
             commandArray.append(mapping)

--- a/configgen/generators/mupen/mupenGenerator.py
+++ b/configgen/generators/mupen/mupenGenerator.py
@@ -20,5 +20,9 @@ class MupenGenerator(Generator):
             mupenControllers.writeControllersConfig(playersControllers)
 
         commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], "--corelib", "/usr/lib/libmupen64plus.so.2.0.0", "--gfx", "/usr/lib/mupen64plus/mupen64plus-video-{}.so".format(system.config['core']),
-                        "--configdir", recalboxFiles.mupenConf, "--datadir", recalboxFiles.mupenConf, rom]
+                        "--configdir", recalboxFiles.mupenConf, "--datadir", recalboxFiles.mupenConf]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+        commandArray.append(rom)
+
         return Command.Command(videomode=system.config['videomode'], array=commandArray, env={"SDL_VIDEO_GL_DRIVER":"/usr/lib/libGLESv2.so"})

--- a/configgen/generators/ppsspp/ppssppGenerator.py
+++ b/configgen/generators/ppsspp/ppssppGenerator.py
@@ -26,7 +26,10 @@ class PPSSPPGenerator(Generator):
                 break
 
         # the command to run  
-        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], rom]
+        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']]]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+        commandArray.append(rom)
         # The next line is a reminder on how to quit PPSSPP with just the HK
         #commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], rom, "--escape-exit"]
         return Command.Command(videomode=system.config['videomode'], array=commandArray, env={"XDG_CONFIG_HOME":recalboxFiles.CONF, "SDL_VIDEO_GL_DRIVER": "/usr/lib/libGLESv2.so", "SDL_VIDEO_EGL_DRIVER": "/usr/lib/libGLESv2.so"}, delay=1)

--- a/configgen/generators/reicast/reicastGenerator.py
+++ b/configgen/generators/reicast/reicastGenerator.py
@@ -36,7 +36,10 @@ class ReicastGenerator(Generator):
             cfgfile.close()
                 
         # the command to run  
-        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], rom]
+        commandArray = [recalboxFiles.recalboxBins[system.config['emulator']]]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+        commandArray.append(rom)
         # Here is the trick to make reicast find files :
         # emu.cfg is in $XDG_CONFIG_DIRS or $XDG_CONFIG_HOME. The latter is better
         # VMU will be in $XDG_DATA_HOME because it needs rw access -> /recalbox/share/saves/dreamcast

--- a/configgen/generators/scummvm/scummvmGenerator.py
+++ b/configgen/generators/scummvm/scummvmGenerator.py
@@ -20,11 +20,13 @@ class ScummVMGenerator(Generator):
         romName = os.path.splitext(os.path.basename(rom))[0]
         # Get rom name without extension
         commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], 
-			"--joystick=0", 
-			"--screenshotspath="+recalboxFiles.screenshotsDir, 
-			"--extrapath=/usr/share/scummvm",
-			"--savepath="+recalboxFiles.scummvmSaves,
-			"--path=""{}""".format(romPath),
-			"""{}""".format(romName)]
-			
+                        "--joystick=0", 
+                        "--screenshotspath="+recalboxFiles.screenshotsDir, 
+                        "--extrapath=/usr/share/scummvm",
+                        "--savepath="+recalboxFiles.scummvmSaves,
+                        "--path=""{}""".format(romPath)]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
+        commandArray.append("""{}""".format(romName))
+
         return Command.Command(videomode='default', array=commandArray, env={"SDL_VIDEO_GL_DRIVER":"/usr/lib/libGLESv2.so"})

--- a/configgen/generators/vice/viceGenerator.py
+++ b/configgen/generators/vice/viceGenerator.py
@@ -22,5 +22,7 @@ class ViceGenerator(Generator):
         commandArray = [recalboxFiles.recalboxBins[system.config['emulator']], 
                         "-config", recalboxFiles.viceConfig,
                         "-autostart", rom]
+        if 'args' in system.config and system.config['args'] is not None:
+            commandArray.extend(system.config['args'])
 
         return Command.Command(videomode='default', array=commandArray,  env={"SDL_VIDEO_GL_DRIVER": "/usr/lib/libGLESv2.so"})


### PR DESCRIPTION
One can add some arguments to the emulator command line
All systems were tested but linapple, dosbox, fba2x, vice, reicast. Kodi hoesn't have this featre
It's only activated if system.security.enabled != 1 for security purpose

for example :
```
snes.args=--record rtmp://live-cdg.twitch.tv/app/live_XXXXXXXXXXXXXXXXXXXXXXXX --recordconfig /recalbo/share/system/configs/retroarch/twitch.cfg
scummvm.args=--gui-theme=scummclassic
```