### PR TITLE
Add reset combo for mupen64plus

### DIFF
--- a/configgen/generators/mupen/mupenConfig.py
+++ b/configgen/generators/mupen/mupenConfig.py
@@ -34,6 +34,8 @@ def writeHotKeyConfig(controllers):
 				mupenSettings.save('Joy Mapping Save State', "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['y'])))
 			if 'x' in controllers['1'].inputs:	
 				mupenSettings.save('Joy Mapping Load State', "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['x'])))
+			if 'a' in controllers['1'].inputs:	
+				mupenSettings.save('Joy Mapping Reset', "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['a'])))
 			if 'pageup' in controllers['1'].inputs:	
 				mupenSettings.save('Joy Mapping Screenshot', "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['pageup'])))
 			if 'up' in controllers['1'].inputs:	


### PR DESCRIPTION
Allow mupen64plus to reset the game by pressing HK+A, like in retroarch cores.
I hope I'm not being naive about how this works.
