### PR TITLE
Hdmi timings + fix a value when DrawFramerate is missing in es_settings.cfg

### DIFF
--- a/configgen/Emulator.py
+++ b/configgen/Emulator.py
@@ -71,8 +71,11 @@ class Emulator():
             self.config['ratio'] = ratio
 
     def updateDrawFPS(self):
-        esConfig = ET.parse(recalboxFiles.esSettings)
-        value = esConfig.find("./bool[@name='DrawFramerate']").attrib["value"]
+        try:
+            esConfig = ET.parse(recalboxFiles.esSettings)
+            value = esConfig.find("./bool[@name='DrawFramerate']").attrib["value"]
+        except:
+            value = 'false'
         if value not in ['false', 'true']:
             value = 'false'
         self.config['showFPS'] = value

--- a/configgen/utils/videoMode.py
+++ b/configgen/utils/videoMode.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import recalboxFiles
+import re
 from settings.unixSettings import UnixSettings
 
 # Set a specific video mode
@@ -9,7 +10,13 @@ def setVideoMode(videomode):
     os.system(createVideoModeLine(videomode))
 
 def createVideoModeLine(videoMode):
-    return "tvservice -e '{}'".format(videoMode)
+    # pattern (CEA|DMT) [0-9]{1,2} HDMI
+    if re.match("^(CEA|DMT) [0-9]{1,2}( HDMI)?$", videoMode):
+        return "tvservice -e '{}'".format(videoMode)
+    if re.match("^hdmi_cvt [\d\s]{10,20}$", videoMode):
+        return "vcgencmd {} && tvservice -e 'DMT 87'".format(videoMode)
+    if re.match("^hdmi_timings [\d\s]{48,58}$", videoMode):
+        return "vcgencmd {} && tvservice -e 'DMT 87'".format(videoMode)
 
 # Set a specific video mode
 def isSupported(index, mode="CEA", drive="HDMI"):

--- a/configgen/utils/videoMode.py
+++ b/configgen/utils/videoMode.py
@@ -30,4 +30,4 @@ def setPreffered():
     if esVideoMode is None:
         os.system("tvservice -p")
     else:
-        os.system("tvservice -e '{}'".format(esVideoMode))
+        setVideoMode(esVideoMode)


### PR DESCRIPTION
Since https://github.com/recalbox/recalbox-buildroot/pull/570 we can set special resolutions on the fly. This PR allows new video modes that can be set in recalbox.conf. See https://github.com/raspberrypi/firmware/issues/637

In recalbox.conf now one can set for example:
- `snes.videomode=hdmi_cvt 800 600 60`
- `snes.videomode=hdmi_timings 640 1 29 60 70 480 1 1 3 23 0 0 0 60 1 12800000 1`

This is going to be VERY useful for CRT.

There s also a small fix that would make configgen crash if DrawFramerate was missing from es_settings.cfg (which is the case right after installing Recalbox)