### PR TITLE
libretro: now can update with recalbox

### DIFF
--- a/configgen/generators/libretro/libretroConfig.py
+++ b/configgen/generators/libretro/libretroConfig.py
@@ -165,3 +165,24 @@ def writeLibretroConfigToFile(config):
     for setting in config:
         libretroSettings.save(setting, config[setting])
 
+
+def updateLibretroConfig(version):
+    # Version is unsued so far, but who knows, one day
+    try: 
+        # Read files
+        sourceSettings = UnixSettings(recalboxFiles.retroarchInitCustomOrigin, separator=' ')
+        sourceConf = sourceSettings.loadFile()
+        destSettings = UnixSettings(recalboxFiles.retroarchCustomOrigin, separator=' ')
+        destConf = destSettings.loadFile()
+        
+        # Compare missing keys
+        for key, value in sourceConf.iteritems():
+            if key not in destConf: destConf[key] = value
+        # Save
+        for key, value in destConf.iteritems():
+            destSettings.save(key, value)
+            
+        return True
+    except:
+        print "Libretro update failed !"
+        return False

--- a/configgen/generators/libretro/libretroGenerator.py
+++ b/configgen/generators/libretro/libretroGenerator.py
@@ -10,6 +10,20 @@ import os.path
 
 class LibretroGenerator(Generator):
     # Main entry of the module
+    def config_upgrade(self, version):
+        '''
+        Upgrade the user's configuration file with new values added to the
+        system configuration file upgraded by S11Share:do_upgrade()
+        
+        Args: 
+            version (str): New Recalbox version
+            
+        Returns (bool):
+            Returns True if this Generators sucessfully handled the upgrade.
+        '''
+        return libretroConfig.updateLibretroConfig(version)
+    
+    
     # Configure retroarch and return a command
     def generate(self, system, rom, playersControllers):
         # Settings recalbox default config file if no user defined one

--- a/configgen/recalboxFiles.py
+++ b/configgen/recalboxFiles.py
@@ -33,6 +33,7 @@ retroarchRoot = CONF + '/retroarch'
 retroarchCustom = retroarchRoot + '/retroarchcustom.cfg'
 retroarchCustomOrigin = retroarchRoot + "/retroarchcustom.cfg.origin"
 retroarchCoreCustom = retroarchRoot + "/cores/retroarch-core-options.cfg"
+retroarchInitCustomOrigin = HOME_INIT + "configs/retroarch/retroarchcustom.cfg.origin"
 
 retroarchCores = "/usr/lib/libretro/"
 shadersRoot = "/recalbox/share/shaders/presets/"

--- a/configgen/settings/unixSettings.py
+++ b/configgen/settings/unixSettings.py
@@ -59,3 +59,18 @@ class UnixSettings():
                         if m:
                             res[m.group(1)] = m.group(2);
         return res
+
+    def loadFile(self):
+        result = dict()
+        separ = self.separator
+        if separ is not '':
+            separ += "?"
+        with open(self.settingsFile) as lines:
+            for line in lines:
+                m = re.match(r"^(.*)" + separ + "=" + separ + '"?(.+)"?', line)
+                if m:
+                    key, value = line.split('=', 1)
+                    key = key.strip()
+                    value = value.strip()
+                    result[key] = value
+        return result


### PR DESCRIPTION
When required, the retroarchcustom.cfg.origin will be updated with new vars from the share_init version