### PR TITLE
Fix LinApple crash with FAT32 share, verbose successful upgrades

### DIFF
--- a/configgen/generators/libretro/libretroConfig.py
+++ b/configgen/generators/libretro/libretroConfig.py
@@ -173,8 +173,6 @@ def updateLibretroConfig(version):
         sourceSettings = UnixSettings(recalboxFiles.retroarchInitCustomOrigin, separator=' ')
         sourceConf = sourceSettings.loadFile()
         destFiles = [recalboxFiles.retroarchCustomOrigin, recalboxFiles.retroarchCustom]
-        destSettings = UnixSettings(recalboxFiles.retroarchCustomOrigin, separator=' ')
-        destConf = destSettings.loadFile()
         
         for file in destFiles:
             destSettings = UnixSettings(file, separator=' ')

--- a/configgen/generators/libretro/libretroConfig.py
+++ b/configgen/generators/libretro/libretroConfig.py
@@ -172,16 +172,20 @@ def updateLibretroConfig(version):
         # Read files
         sourceSettings = UnixSettings(recalboxFiles.retroarchInitCustomOrigin, separator=' ')
         sourceConf = sourceSettings.loadFile()
+        destFiles = [recalboxFiles.retroarchCustomOrigin, recalboxFiles.retroarchCustom]
         destSettings = UnixSettings(recalboxFiles.retroarchCustomOrigin, separator=' ')
         destConf = destSettings.loadFile()
         
-        # Compare missing keys
-        for key, value in sourceConf.iteritems():
-            if key not in destConf: destConf[key] = value
-        # Save
-        for key, value in destConf.iteritems():
-            destSettings.save(key, value)
-        
+        for file in destFiles:
+            destSettings = UnixSettings(file, separator=' ')
+            destConf = destSettings.loadFile()
+            # Compare missing keys
+            for key, value in sourceConf.iteritems():
+                if key not in destConf: destConf[key] = value
+            # Save
+            for key, value in destConf.iteritems():
+                destSettings.save(key, value)
+            
         print("LibretroConfig 's configuration successfully upgraded")
         return True
     except:

--- a/configgen/generators/libretro/libretroConfig.py
+++ b/configgen/generators/libretro/libretroConfig.py
@@ -181,7 +181,8 @@ def updateLibretroConfig(version):
         # Save
         for key, value in destConf.iteritems():
             destSettings.save(key, value)
-            
+        
+        print("LibretroConfig 's configuration successfully upgraded")
         return True
     except:
         print "Libretro update failed !"

--- a/configgen/generators/linapple/linappleGenerator.py
+++ b/configgen/generators/linapple/linappleGenerator.py
@@ -5,6 +5,7 @@ Created on Mar 6, 2016
 '''
 
 import os
+import shutil
 import Command
 from generators.Generator import Generator
 from generators.linapple.linappleConfig import LinappleConfig
@@ -57,7 +58,7 @@ class LinappleGenerator(Generator):
                 return False
             usr_filename = os.path.join(self.path_user, r)
             if not os.path.exists(usr_filename):
-                os.symlink(sys_filename, usr_filename)
+                shutil.copyfile(sys_filename, usr_filename)
 
         return True
 
@@ -131,6 +132,7 @@ class LinappleGenerator(Generator):
 
         # Save config file (original/updated) to user's directory
         config.save(filename=usr_conf)
+        print("{} 's configuration successfully upgraded".format(self.__class__.__name__))
         return True
 
 # Local Variables:


### PR DESCRIPTION
Linapple: creating a symlink when share is on a FAT32 FS would crash (and crash the whole S12 configgen upgrade process if existing). Now we copy.

libretro: inform the update is successfull + also update retroarchCustom.cfg